### PR TITLE
Fix crash on include cursors without source file (fixes CUDA builds)

### DIFF
--- a/src/include_graph_parser.cc
+++ b/src/include_graph_parser.cc
@@ -424,6 +424,12 @@ enum CXChildVisitResult inclusion_cursor_visitor(
         clang_getFileLocation(clang_getCursorLocation(cursor), &source_file,
             &line, &column, &offset);
 
+        if(source_file == nullptr) {
+            LOG(debug) << "WARNING: Cannot find source file for include text: "
+                       << get_raw_include_text(cursor);
+            return CXChildVisit_Continue;
+        }
+
         const std::string source_file_str{
             clang_getCString(clang_getFileName(source_file))};
 


### PR DESCRIPTION
fixes https://github.com/bkryza/clang-include-graph/issues/29

This PR adds a check to skip include directives when `clang_getFileLocation` returns a null `source_file` handle, preventing std::string construction from null while preserving normal include graph generation.

Example of the warning log message: 
```
=== WARNING: Cannot find source file for include text: __clang_cuda_runtime_wrapper.h
```